### PR TITLE
I noticed that the ImmidiateDestination and ImmidiateOrigin formattin…

### DIFF
--- a/ACHGenerator/ACHFileGenerator.cs
+++ b/ACHGenerator/ACHFileGenerator.cs
@@ -249,7 +249,7 @@ namespace ACHGenerator
                             //If the length of the number string is less than the 
                             //required field length, post-pend with white space until correct length has been reached.
                             //(Alphanumeric Rule)
-                            propertyValue = propertyValue.Insert(propertyValue.Length, " ");
+                            propertyValue = propertyValue.PadRight(attribute.Length, ' ');
                         }
 
                         recordLine = recordLine.Insert(attribute.Position - 1, propertyValue);

--- a/ACHGenerator/DTO/ACHTransaction.cs
+++ b/ACHGenerator/DTO/ACHTransaction.cs
@@ -12,10 +12,10 @@ namespace ACHGenerator.DTO
         [ACHField(Position = 2, Length = 2)]
         private string PriorityCode => "01";
 
-        [ACHField(Position = 4, Length = 10, Format = " {0}")]
+        [ACHField(Position = 4, Length = 10, Format = "{0}")]
         public string ImmidiateDestination { get; set; }
 
-        [ACHField(Position = 14, Length = 10, Format = " {0}")]
+        [ACHField(Position = 14, Length = 10, Format = "{0}")]
         public string ImmidiateOrigin { get; set; }
 
         [ACHField(Position = 24, Length = 6, Format = "yyMMdd")]

--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -26,7 +26,29 @@ namespace UnitTests
             var line = generator.GenerateRecordLine(fileHeaderRecord);
 
             Assert.AreEqual(line,
-                "101 121140399 1234567891709151230A094101Bank Of America        Pedro's Bank           00001235");
+                "101121140399 123456789 1709151230A094101Bank Of America        Pedro's Bank           00001235");
+        }
+        
+        [Test]
+        public void CanGenerateFileHeaderRecordForTenDigits()
+        {
+            var generator = new ACHFileGenerator();
+
+            var fileHeaderRecord = new FileHeader
+                {
+                    ImmidiateDestination = "121140399I",
+                    ImmidiateOrigin = "123456789B",
+                    FileCreationDate = new DateTime(2017,9,15,12,30,15),
+                    FileCreationTime = new DateTime(2017, 9, 15, 12, 30, 15),
+                    ImmediateDestinationName = "Bank Of America",
+                    ImmediateOriginName = "Pedro's Bank",
+                    ReferenceCode = 1235
+                };
+
+            var line = generator.GenerateRecordLine(fileHeaderRecord);
+
+            Assert.AreEqual(line,
+                "101121140399I123456789B1709151230A094101Bank Of America        Pedro's Bank           00001235");
         }
 
         [Test]


### PR DESCRIPTION
…g was not correct.  According to the nc.gov site, the sizes of those fields should be 10. Here is an example: https://files.nc.gov/ncosc/documents/eCommerce/bank_of_america_nacha_file_specs.pdf.

I was working with JP Morgan and Truist banks, and both gave me 10 digits for the field ImmidiateOrigin