### PR TITLE
I looked through a few more specs, and I noticed that different banks…

### DIFF
--- a/ACHGenerator/ACHFileGenerator.cs
+++ b/ACHGenerator/ACHFileGenerator.cs
@@ -12,6 +12,9 @@ namespace ACHGenerator
         private static readonly string FillerLine =
             "9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999";
 
+        public char ImmidiateDestinationFiller { get; set; } = ' ';
+        public char ImmidiateOriginFiller { get; set; } = ' ';
+
         public IEnumerable<string> GenerateACH(ACHTransaction transaction)
         {
             var achLines = new List<string>
@@ -249,7 +252,18 @@ namespace ACHGenerator
                             //If the length of the number string is less than the 
                             //required field length, post-pend with white space until correct length has been reached.
                             //(Alphanumeric Rule)
-                            propertyValue = propertyValue.PadRight(attribute.Length, ' ');
+
+                            propertyValue = recordProperty.Name switch
+                            {
+                                // Determine which filler to use based on the property name
+                                // Different banks have different rules for what filler to use
+                                nameof(FileHeader.ImmidiateOrigin) => 
+                                    propertyValue.Insert(0, ImmidiateOriginFiller.ToString()),
+                                nameof(FileHeader.ImmidiateDestination) => 
+                                    propertyValue.Insert(0, ImmidiateDestinationFiller.ToString()),
+                                _ => 
+                                    propertyValue.Insert(propertyValue.Length, " ")
+                            };
                         }
 
                         recordLine = recordLine.Insert(attribute.Position - 1, propertyValue);

--- a/UnitTests/Tests.cs
+++ b/UnitTests/Tests.cs
@@ -26,18 +26,18 @@ namespace UnitTests
             var line = generator.GenerateRecordLine(fileHeaderRecord);
 
             Assert.AreEqual(line,
-                "101121140399 123456789 1709151230A094101Bank Of America        Pedro's Bank           00001235");
+                "101 121140399 1234567891709151230A094101Bank Of America        Pedro's Bank           00001235");
         }
         
         [Test]
-        public void CanGenerateFileHeaderRecordForTenDigits()
+        public void CanGenerateFileHeaderRecordWithTenDigitOrigin()
         {
             var generator = new ACHFileGenerator();
 
             var fileHeaderRecord = new FileHeader
                 {
-                    ImmidiateDestination = "121140399I",
-                    ImmidiateOrigin = "123456789B",
+                    ImmidiateDestination = "121140399",
+                    ImmidiateOrigin = "1234567889",
                     FileCreationDate = new DateTime(2017,9,15,12,30,15),
                     FileCreationTime = new DateTime(2017, 9, 15, 12, 30, 15),
                     ImmediateDestinationName = "Bank Of America",
@@ -48,7 +48,83 @@ namespace UnitTests
             var line = generator.GenerateRecordLine(fileHeaderRecord);
 
             Assert.AreEqual(line,
-                "101121140399I123456789B1709151230A094101Bank Of America        Pedro's Bank           00001235");
+                "101 12114039912345678891709151230A094101Bank Of America        Pedro's Bank           00001235");
+        }
+        
+        [Test]
+        public void CanGenerateFileHeaderRecordWithDifferentPadding()
+        {
+            var generator = new ACHFileGenerator
+            {
+                ImmidiateDestinationFiller = 'b',
+                ImmidiateOriginFiller = 'b'
+            };
+
+            var fileHeaderRecord = new FileHeader
+            {
+                ImmidiateDestination = "121140399",
+                ImmidiateOrigin = "123456789",
+                FileCreationDate = new DateTime(2017,9,15,12,30,15),
+                FileCreationTime = new DateTime(2017, 9, 15, 12, 30, 15),
+                ImmediateDestinationName = "Bank Of America",
+                ImmediateOriginName = "Pedro's Bank",
+                ReferenceCode = 1235
+            };
+
+            var line = generator.GenerateRecordLine(fileHeaderRecord);
+
+            Assert.AreEqual(line,
+                "101b121140399b1234567891709151230A094101Bank Of America        Pedro's Bank           00001235");
+        }
+        
+        [Test]
+        public void CanGenerateFileHeaderRecordWithImmidiateOriginDifferentPadding()
+        {
+            var generator = new ACHFileGenerator
+            {
+                ImmidiateOriginFiller = 'b'
+            };
+
+            var fileHeaderRecord = new FileHeader
+                {
+                    ImmidiateDestination = "121140399",
+                    ImmidiateOrigin = "123456789",
+                    FileCreationDate = new DateTime(2017,9,15,12,30,15),
+                    FileCreationTime = new DateTime(2017, 9, 15, 12, 30, 15),
+                    ImmediateDestinationName = "Bank Of America",
+                    ImmediateOriginName = "Pedro's Bank",
+                    ReferenceCode = 1235
+                };
+
+            var line = generator.GenerateRecordLine(fileHeaderRecord);
+
+            Assert.AreEqual(line,
+                "101 121140399b1234567891709151230A094101Bank Of America        Pedro's Bank           00001235");
+        }
+        
+        [Test]
+        public void CanGenerateFileHeaderRecordWithImmidiateDestinationDifferentPadding()
+        {
+            var generator = new ACHFileGenerator
+            {
+                ImmidiateDestinationFiller = 'b'
+            };
+
+            var fileHeaderRecord = new FileHeader
+                {
+                    ImmidiateDestination = "121140399",
+                    ImmidiateOrigin = "123456789",
+                    FileCreationDate = new DateTime(2017,9,15,12,30,15),
+                    FileCreationTime = new DateTime(2017, 9, 15, 12, 30, 15),
+                    ImmediateDestinationName = "Bank Of America",
+                    ImmediateOriginName = "Pedro's Bank",
+                    ReferenceCode = 1235
+                };
+
+            var line = generator.GenerateRecordLine(fileHeaderRecord);
+
+            Assert.AreEqual(line,
+                "101b121140399 1234567891709151230A094101Bank Of America        Pedro's Bank           00001235");
         }
 
         [Test]


### PR DESCRIPTION
… has different requirements for the fillers on ImmidiateOrigin and ImmidiateDestination.  So I am adding the ability to specify which filler to use.